### PR TITLE
Print the URL to view OpenMM Setup at

### DIFF
--- a/openmmsetup/openmmsetup.py
+++ b/openmmsetup/openmmsetup.py
@@ -735,6 +735,9 @@ def main():
         # Give the server a moment to start before opening the browser.
         time.sleep(1)
         url = f'http://127.0.0.1:{port}'
+
+        print("OpenMM Setup should open automatically in a web browser.")
+        print(f"If this does not occur, you can navigate to <{url}>.")
         webbrowser.open(url)
 
     global server, shutdownEvent


### PR DESCRIPTION
Prints out the URL that the server is running at to standard output.  This should help users running in an environment where Python is unable to launch a browser.

I experimented with showing the message based on the return value of `webbrowser.open()`, but found with my OS and browser that the function doesn't always return immediately for some reason; furthermore, if the browser process starts but can't display a window (user is doing X11 forwarding, for instance), I don't know if this will be detected by Python or not.  So I decided to play it safe and always show the message before OpenMM Setup tries to start the browser.